### PR TITLE
fix: handle wildcard syntax in AST coordinate generation

### DIFF
--- a/py_dpm/api/dpm_xl/ast_generator.py
+++ b/py_dpm/api/dpm_xl/ast_generator.py
@@ -2225,10 +2225,15 @@ class ASTGeneratorAPI:
                     data_cols.sort()
                     data_sheets.sort()
 
-                    # Use context lists if provided, otherwise use extracted lists
-                    rows = context_rows if context_rows else data_rows
-                    cols = context_cols if context_cols else data_cols
-                    sheets = context_sheets if context_sheets else data_sheets
+                    # Helper to check if a list contains only wildcards
+                    def _has_wildcard(values):
+                        return values and any(v == "*" for v in values)
+
+                    # Use context lists if provided and not wildcards, otherwise use extracted lists
+                    # Wildcard values like ['*'] indicate "all values" so we should use data
+                    rows = context_rows if context_rows and not _has_wildcard(context_rows) else data_rows
+                    cols = context_cols if context_cols and not _has_wildcard(context_cols) else data_cols
+                    sheets = context_sheets if context_sheets and not _has_wildcard(context_sheets) else data_sheets
 
                     # Assign coordinates to each data entry
                     for entry in data_entries:

--- a/py_dpm/dpm_xl/utils/serialization.py
+++ b/py_dpm/dpm_xl/utils/serialization.py
@@ -199,11 +199,18 @@ class ASTToJSONVisitor(NodeVisitor):
                         return False
                     return any('-' in str(v) for v in values if v and v != '*')
 
+                # Helper function to detect wildcard syntax (e.g., ['*'])
+                def _has_wildcard_syntax(values):
+                    if not values or not isinstance(values, list):
+                        return False
+                    return any(v == '*' for v in values)
+
                 # Build column order from data if:
                 # - context_cols is empty OR
-                # - context_cols contains range syntax (e.g., ['0010-0080'])
-                # Range syntax means we need actual column codes from data for coordinate calculation
-                if not context_cols or _has_range_syntax(context_cols):
+                # - context_cols contains range syntax (e.g., ['0010-0080']) OR
+                # - context_cols contains wildcard syntax (e.g., ['*'])
+                # Range/wildcard syntax means we need actual column codes from data for coordinate calculation
+                if not context_cols or _has_range_syntax(context_cols) or _has_wildcard_syntax(context_cols):
                     # Extract unique columns from data in order
                     context_cols = []
                     seen_cols = set()

--- a/tests/api/test_ast_coordinates.py
+++ b/tests/api/test_ast_coordinates.py
@@ -229,6 +229,53 @@ class TestAddCoordinatesToAst:
         assert result["data"][0]["x"] == 2  # row 0020
         assert result["data"][1]["x"] == 1  # row 0010
 
+    def test_wildcard_cols_uses_data_values(self, api):
+        """Context with wildcard columns should use data-extracted column values.
+
+        This is a regression test for issue #75: when context contains c* (wildcard),
+        the y coordinates should be calculated from the actual column codes in data.
+        """
+        ast = {
+            "class_name": "VarID",
+            "data": [
+                {"datapoint": 1, "operand_reference_id": 100, "row": "0010", "column": "0010"},
+                {"datapoint": 2, "operand_reference_id": 101, "row": "0010", "column": "0020"},
+                {"datapoint": 3, "operand_reference_id": 102, "row": "0010", "column": "0030"},
+            ]
+        }
+        # Context with wildcard - should fall back to data-extracted values
+        context = {"cols": ["*"]}
+
+        result = api._add_coordinates_to_ast(ast, context=context)
+
+        # y should be calculated from data columns sorted: ["0010", "0020", "0030"]
+        assert result["data"][0]["y"] == 1  # column 0010
+        assert result["data"][1]["y"] == 2  # column 0020
+        assert result["data"][2]["y"] == 3  # column 0030
+
+    def test_wildcard_rows_uses_data_values(self, api):
+        """Context with wildcard rows should use data-extracted row values.
+
+        Similar to test_wildcard_cols_uses_data_values but for row wildcards.
+        """
+        ast = {
+            "class_name": "VarID",
+            "data": [
+                {"datapoint": 1, "operand_reference_id": 100, "row": "0010", "column": "0010"},
+                {"datapoint": 2, "operand_reference_id": 101, "row": "0020", "column": "0010"},
+                {"datapoint": 3, "operand_reference_id": 102, "row": "0030", "column": "0010"},
+            ]
+        }
+        # Context with wildcard - should fall back to data-extracted values
+        context = {"rows": ["*"]}
+
+        result = api._add_coordinates_to_ast(ast, context=context)
+
+        # x should be calculated from data rows sorted: ["0010", "0020", "0030"]
+        assert result["data"][0]["x"] == 1  # row 0010
+        assert result["data"][1]["x"] == 2  # row 0020
+        assert result["data"][2]["x"] == 3  # row 0030
+
     # ========== EDGE CASES ==========
 
     def test_empty_data_array(self, api):


### PR DESCRIPTION
When using wildcards like c* or r* in WITH clauses, the AST coordinate generation now correctly extracts actual column/row/sheet codes from the data instead of using the literal wildcard value.

Fixes #75