### PR TITLE
feat: return semantic validation warnings in result instead of warning…

### DIFF
--- a/py_dpm/dpm_xl/operators/aggregate.py
+++ b/py_dpm/dpm_xl/operators/aggregate.py
@@ -1,5 +1,3 @@
-import warnings
-
 import pandas as pd
 
 from py_dpm.dpm_xl.types.scalar import Integer, Number, ScalarFactory
@@ -8,6 +6,7 @@ from py_dpm.exceptions import exceptions
 from py_dpm.dpm_xl.operators.base import Operator, Binary, Unary, Complex
 from py_dpm.dpm_xl.utils import tokens
 from py_dpm.dpm_xl.symbols import RecordSet
+from py_dpm.dpm_xl.warning_collector import add_semantic_warning
 
 
 class AggregateOperator(Unary):
@@ -94,7 +93,7 @@ class AggregateOperator(Unary):
         key_components = operand.get_key_components_names()
         cls.check_grouping(grouping_clause, key_components)
         if len(grouping_clause) == len(key_components):
-            warnings.warn(f"Grouping by all the key components of the Recordset: {','.join(key_components)}")
+            add_semantic_warning(f"Grouping by all the key components of the Recordset: {','.join(key_components)}")
 
         return cls.create_grouped_recordset(operand, grouping_clause, final_type)
 

--- a/py_dpm/dpm_xl/operators/base.py
+++ b/py_dpm/dpm_xl/operators/base.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Union
 
 import pandas as pd
@@ -10,6 +9,7 @@ from py_dpm.dpm_xl.types.promotion import binary_implicit_type_promotion, binary
 from py_dpm.exceptions.exceptions import SemanticError
 from py_dpm.dpm_xl.utils.operands_mapping import generate_new_label, set_operand_label
 from py_dpm.dpm_xl.symbols import ConstantOperand, FactComponent, RecordSet, Scalar, ScalarSet, Structure
+from py_dpm.dpm_xl.warning_collector import add_semantic_warning
 
 
 class Operator:
@@ -196,7 +196,7 @@ class Binary(Operator):
                 if len(result_dataframe) == 0:
                     raise SemanticError("2-2", op=cls.op, left=left.name, right=right.name)
                 if len(result_dataframe) < len(left.records):
-                    warnings.warn(
+                    add_semantic_warning(
                         f"There is no correspondence between recordset {left.name} and recordset {right.name}.")
 
             return result_structure, result_dataframe

--- a/py_dpm/dpm_xl/operators/conditional.py
+++ b/py_dpm/dpm_xl/operators/conditional.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Union
 
 import pandas as pd
@@ -11,6 +10,7 @@ from py_dpm.exceptions.exceptions import SemanticError
 from py_dpm.dpm_xl.operators.base import Binary, Operator
 from py_dpm.dpm_xl.utils import tokens
 from py_dpm.dpm_xl.symbols import ConstantOperand, RecordSet, Scalar, Structure
+from py_dpm.dpm_xl.warning_collector import add_semantic_warning
 
 
 class ConditionalOperator(Operator):
@@ -348,7 +348,7 @@ class Filter(ConditionalOperator):
         if isinstance(selection, RecordSet) and isinstance(condition, RecordSet):
 
             if selection.has_only_global_components:
-                warnings.warn(
+                add_semantic_warning(
                     f"Performing a filter operation on recordset: {selection.name} which has only global key components")
 
             check_condition_type = ScalarFactory().scalar_factory("Boolean")

--- a/py_dpm/dpm_xl/semantic_analyzer.py
+++ b/py_dpm/dpm_xl/semantic_analyzer.py
@@ -1,4 +1,3 @@
-import warnings
 from abc import ABC
 
 import pandas as pd
@@ -66,6 +65,7 @@ from py_dpm.dpm_xl.symbols import (
     ScalarSet,
     Structure,
 )
+from py_dpm.dpm_xl.warning_collector import add_semantic_warning
 
 
 class InputAnalyzer(ASTTemplate, ABC):
@@ -306,7 +306,7 @@ class InputAnalyzer(ASTTemplate, ABC):
             raise exceptions.SemanticError("4-4-0-1", op=node.op)
 
         if operand.has_only_global_components:
-            warnings.warn(
+            add_semantic_warning(
                 f"Performing an aggregation on recordset: {operand.name} which has only global key components"
             )
 

--- a/py_dpm/dpm_xl/types/promotion.py
+++ b/py_dpm/dpm_xl/types/promotion.py
@@ -1,8 +1,7 @@
-import warnings
-
 from py_dpm.dpm_xl.types.scalar import Boolean, Date, Duration, Integer, Item, Mixed, Null, Number, \
     ScalarType, String, Subcategory, TimeInterval, TimePeriod
 from py_dpm.exceptions.exceptions import SemanticError
+from py_dpm.dpm_xl.warning_collector import add_semantic_warning
 
 implicit_type_promotion_dict = {
     String: {String},
@@ -38,8 +37,15 @@ def binary_implicit_type_promotion(
                 left_implicities.intersection(right_implicities)):  # general case and date->str and boolean-> str in the str operator
 
             if warning_raising:
-                warnings.warn(
-                    f"Implicit promotion between {left} and {right} and op_type={op_type_to_check}.")
+                if error_info:
+                    add_semantic_warning(
+                        f"Implicit promotion between {left} and {right} in: "
+                        f"{error_info['left_name']} {error_info['op']} {error_info['right_name']}"
+                    )
+                else:
+                    add_semantic_warning(
+                        f"Implicit promotion between {left} and {right}."
+                    )
             if return_type:
                 binary_check_interval(result_operand=return_type, left_operand=left, right_operand=right, op_type_to_check=op_type_to_check,
                                       return_type=return_type, interval_allowed=interval_allowed, error_info=error_info)
@@ -67,7 +73,13 @@ def binary_implicit_type_promotion(
             raise SemanticError("3-2", type_1=left, type_2=right, type_op=op_type_to_check, origin=origin)
     else:
         if warning_raising:
-            warnings.warn(f"Implicit promotion between {left} and {right}.")
+            if error_info:
+                add_semantic_warning(
+                    f"Implicit promotion between {left} and {right} in: "
+                    f"{error_info['left_name']} {error_info['op']} {error_info['right_name']}"
+                )
+            else:
+                add_semantic_warning(f"Implicit promotion between {left} and {right}.")
         if return_type and (left.is_included(right_implicities) or right.is_included(left_implicities)):
             return return_type
         elif left.is_included(right_implicities):

--- a/py_dpm/dpm_xl/warning_collector.py
+++ b/py_dpm/dpm_xl/warning_collector.py
@@ -1,0 +1,94 @@
+"""
+Warning collector for semantic validation.
+
+This module provides a thread-local warning collector that can be used to capture
+warnings during semantic analysis instead of emitting them via warnings.warn().
+"""
+
+import threading
+from contextlib import contextmanager
+from typing import List, Optional
+
+
+# Thread-local storage for the warning collector
+_local = threading.local()
+
+
+class WarningCollector:
+    """
+    Collects semantic validation warnings.
+
+    This class provides a context manager interface to collect warnings during
+    semantic analysis. When active, warnings can be added via add_warning() and
+    retrieved via get_warnings().
+    """
+
+    def __init__(self) -> None:
+        self._warnings: List[str] = []
+
+    def add_warning(self, message: str) -> None:
+        """Add a warning message to the collector."""
+        self._warnings.append(message)
+
+    def get_warnings(self) -> List[str]:
+        """Get all collected warnings."""
+        return self._warnings.copy()
+
+    def get_combined_warning(self) -> Optional[str]:
+        """
+        Get all warnings combined into a single string.
+
+        Returns:
+            None if no warnings, otherwise all warnings joined with newlines.
+        """
+        if not self._warnings:
+            return None
+        return "\n".join(self._warnings)
+
+    def clear(self) -> None:
+        """Clear all collected warnings."""
+        self._warnings.clear()
+
+
+def get_active_collector() -> Optional[WarningCollector]:
+    """Get the currently active warning collector, if any."""
+    return getattr(_local, "collector", None)
+
+
+def add_semantic_warning(message: str) -> None:
+    """
+    Add a warning to the active collector.
+
+    If no collector is active, the warning is silently discarded.
+    This allows the warning calls to work both within and outside of
+    a collection context.
+
+    Args:
+        message: The warning message to add.
+    """
+    collector = get_active_collector()
+    if collector is not None:
+        collector.add_warning(message)
+
+
+@contextmanager
+def collect_warnings():
+    """
+    Context manager to collect warnings during semantic analysis.
+
+    Usage:
+        with collect_warnings() as collector:
+            # Perform semantic analysis
+            ...
+        warnings = collector.get_combined_warning()
+
+    Yields:
+        WarningCollector: The collector that will contain any warnings.
+    """
+    collector = WarningCollector()
+    old_collector = getattr(_local, "collector", None)
+    _local.collector = collector
+    try:
+        yield collector
+    finally:
+        _local.collector = old_collector

--- a/tests/unit/dpm_xl/test_warning_collector.py
+++ b/tests/unit/dpm_xl/test_warning_collector.py
@@ -1,0 +1,144 @@
+"""Tests for the semantic validation warning collector."""
+
+import pytest
+import threading
+from py_dpm.dpm_xl.warning_collector import (
+    WarningCollector,
+    collect_warnings,
+    add_semantic_warning,
+    get_active_collector,
+)
+
+
+class TestWarningCollector:
+    """Tests for the WarningCollector class."""
+
+    def test_add_warning(self):
+        """Test adding a warning to the collector."""
+        collector = WarningCollector()
+        collector.add_warning("Test warning")
+        assert collector.get_warnings() == ["Test warning"]
+
+    def test_multiple_warnings(self):
+        """Test adding multiple warnings."""
+        collector = WarningCollector()
+        collector.add_warning("Warning 1")
+        collector.add_warning("Warning 2")
+        collector.add_warning("Warning 3")
+        assert collector.get_warnings() == ["Warning 1", "Warning 2", "Warning 3"]
+
+    def test_get_warnings_returns_copy(self):
+        """Test that get_warnings returns a copy of the list."""
+        collector = WarningCollector()
+        collector.add_warning("Test warning")
+        warnings = collector.get_warnings()
+        warnings.append("Modified")
+        assert collector.get_warnings() == ["Test warning"]
+
+    def test_get_combined_warning_none(self):
+        """Test get_combined_warning returns None when no warnings."""
+        collector = WarningCollector()
+        assert collector.get_combined_warning() is None
+
+    def test_get_combined_warning_single(self):
+        """Test get_combined_warning with single warning."""
+        collector = WarningCollector()
+        collector.add_warning("Single warning")
+        assert collector.get_combined_warning() == "Single warning"
+
+    def test_get_combined_warning_multiple(self):
+        """Test get_combined_warning with multiple warnings."""
+        collector = WarningCollector()
+        collector.add_warning("Warning 1")
+        collector.add_warning("Warning 2")
+        assert collector.get_combined_warning() == "Warning 1\nWarning 2"
+
+    def test_clear(self):
+        """Test clearing warnings."""
+        collector = WarningCollector()
+        collector.add_warning("Warning 1")
+        collector.add_warning("Warning 2")
+        collector.clear()
+        assert collector.get_warnings() == []
+        assert collector.get_combined_warning() is None
+
+
+class TestCollectWarningsContextManager:
+    """Tests for the collect_warnings context manager."""
+
+    def test_context_manager_basic(self):
+        """Test basic context manager usage."""
+        with collect_warnings() as collector:
+            add_semantic_warning("Test warning")
+        assert collector.get_combined_warning() == "Test warning"
+
+    def test_context_manager_no_warnings(self):
+        """Test context manager with no warnings."""
+        with collect_warnings() as collector:
+            pass
+        assert collector.get_combined_warning() is None
+
+    def test_nested_context_managers(self):
+        """Test nested context managers."""
+        with collect_warnings() as outer:
+            add_semantic_warning("Outer warning")
+            with collect_warnings() as inner:
+                add_semantic_warning("Inner warning")
+            # After inner context, outer should be restored
+            add_semantic_warning("Outer warning 2")
+
+        assert inner.get_warnings() == ["Inner warning"]
+        assert outer.get_warnings() == ["Outer warning", "Outer warning 2"]
+
+    def test_no_active_collector(self):
+        """Test add_semantic_warning when no collector is active."""
+        # This should not raise an error, just silently discard
+        add_semantic_warning("Warning without collector")
+        assert get_active_collector() is None
+
+    def test_thread_isolation(self):
+        """Test that warning collectors are thread-local."""
+        results = {}
+
+        def thread_func(thread_id):
+            with collect_warnings() as collector:
+                add_semantic_warning(f"Thread {thread_id} warning")
+                results[thread_id] = collector.get_combined_warning()
+
+        threads = [threading.Thread(target=thread_func, args=(i,)) for i in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert results[0] == "Thread 0 warning"
+        assert results[1] == "Thread 1 warning"
+        assert results[2] == "Thread 2 warning"
+
+    def test_exception_handling(self):
+        """Test that context manager properly restores state on exception."""
+        try:
+            with collect_warnings() as collector:
+                add_semantic_warning("Before exception")
+                raise ValueError("Test exception")
+        except ValueError:
+            pass
+
+        # After exception, there should be no active collector
+        assert get_active_collector() is None
+        # But the collector should still have the warning from before the exception
+        assert collector.get_combined_warning() == "Before exception"
+
+
+class TestGetActiveCollector:
+    """Tests for get_active_collector function."""
+
+    def test_no_active_collector(self):
+        """Test when no collector is active."""
+        assert get_active_collector() is None
+
+    def test_with_active_collector(self):
+        """Test when a collector is active."""
+        with collect_warnings() as collector:
+            active = get_active_collector()
+            assert active is collector


### PR DESCRIPTION
…gs.warn()

- Add `warning` field to SemanticValidationResult dataclass
- Create thread-safe WarningCollector for capturing warnings during analysis
- Replace all warnings.warn() calls with add_semantic_warning()
- Enhanced implicit promotion warnings to include operand context
- Validations with warnings remain valid (is_valid=True)
- Add comprehensive tests for warning collector

Closes #74