### PR TITLE
fix: resolve correct module URLs when querying by release_id

### DIFF
--- a/py_dpm/dpm/data/__init__.py
+++ b/py_dpm/dpm/data/__init__.py
@@ -37,6 +37,33 @@ def _load_module_schema_mapping() -> list[dict]:
     return mappings
 
 
+def get_module_schema_ref_by_version(
+    module_code: str,
+    version: str,
+) -> Optional[str]:
+    """
+    Look up the XBRL schema reference URL for a module by version number.
+
+    Args:
+        module_code: The module code (e.g., "COREP_Con", "AE")
+        version: The module version number (e.g., "1.2.0")
+
+    Returns:
+        The XbrlSchemaRef URL if found, None otherwise
+    """
+    mappings = _load_module_schema_mapping()
+
+    module_code_upper = module_code.upper()
+    for candidate in reversed(mappings):
+        if (
+            candidate["module_code"].upper() == module_code_upper
+            and candidate["version"] == version
+        ):
+            return candidate["xbrl_schema_ref"]
+
+    return None
+
+
 def get_module_schema_ref(
     module_code: str,
     date: Optional[str] = None,

--- a/py_dpm/dpm/queries/explorer_queries.py
+++ b/py_dpm/dpm/queries/explorer_queries.py
@@ -2,7 +2,7 @@ from typing import Optional, List, Dict, Any
 
 from sqlalchemy.orm import Session, aliased
 
-from py_dpm.dpm.data import get_module_schema_ref
+from py_dpm.dpm.data import get_module_schema_ref, get_module_schema_ref_by_version
 from py_dpm.dpm.models import (
     VariableVersion,
     TableVersionCell,
@@ -168,6 +168,7 @@ class ExplorerQuery:
             session.query(
                 Framework.code.label("framework_code"),
                 ModuleVersion.code.label("module_code"),
+                ModuleVersion.versionnumber.label("module_versionnumber"),
                 ModuleVersion.startreleaseid.label("module_startreleaseid"),
                 ModuleVersion.endreleaseid.label("module_endreleaseid"),
                 ModuleVersion.fromreferencedate.label("module_fromreferencedate"),
@@ -209,6 +210,15 @@ class ExplorerQuery:
         row = rows[0]
         framework_code = row.framework_code
         resolved_module_code = row.module_code
+
+        # Try the static mapping by module code + version number
+        version_number = row.module_versionnumber
+        if version_number:
+            static_url = get_module_schema_ref_by_version(
+                resolved_module_code, version_number
+            )
+            if static_url:
+                return static_url
 
         # Determine which release_code to embed in the URL
         if release_code is not None:

--- a/tests/integration/api/test_explorer.py
+++ b/tests/integration/api/test_explorer.py
@@ -268,6 +268,40 @@ class TestExplorerQueryModuleUrlIntegration(unittest.TestCase):
         )
         self.assertEqual(url, expected_url)
 
+    def test_get_module_url_by_release_id_uses_static_mapping(self):
+        """Test that querying by release_id returns the static mapping URL
+        when the module version matches a known entry in the CSV."""
+        # Add a release and module version that matches a static mapping entry.
+        # AE version 1.2.0 is in the CSV with the correct ITS-based URL.
+        release_34 = Release(releaseid=34, code="3.4")
+        framework_ae = Framework(frameworkid=20, code="AE")
+        module_ae = Module(moduleid=200, frameworkid=framework_ae.frameworkid)
+        module_version_ae = ModuleVersion(
+            modulevid=2000,
+            moduleid=module_ae.moduleid,
+            code="AE",
+            versionnumber="1.2.0",
+            startreleaseid=1,
+            endreleaseid=None,
+        )
+
+        self.session.add_all(
+            [release_34, framework_ae, module_ae, module_version_ae]
+        )
+        self.session.commit()
+
+        url = ExplorerQuery.get_module_url(
+            self.session,
+            module_code="AE",
+            release_id=34,
+        )
+
+        expected_url = (
+            "http://www.eba.europa.eu/eu/fr/xbrl/crr/fws/ae/"
+            "its-005-2020/2022-03-01/mod/ae.xsd"
+        )
+        self.assertEqual(url, expected_url)
+
 
 class TestGetVariableByCode(unittest.TestCase):
     """Tests for get_variable_by_code and get_variables_by_codes methods."""

--- a/tests/unit/dpm/test_module_schema_mapping.py
+++ b/tests/unit/dpm/test_module_schema_mapping.py
@@ -1,6 +1,6 @@
 import unittest
 
-from py_dpm.dpm.data import get_module_schema_ref
+from py_dpm.dpm.data import get_module_schema_ref, get_module_schema_ref_by_version
 
 
 class TestModuleSchemaMapping(unittest.TestCase):
@@ -62,6 +62,42 @@ class TestModuleSchemaMapping(unittest.TestCase):
         """Test that older module URLs end with .xsd extension."""
         url = get_module_schema_ref("COREP_Con", "2014-01-15")
         self.assertTrue(url.endswith(".xsd"))
+
+
+class TestModuleSchemaMappingByVersion(unittest.TestCase):
+    """Test cases for the version-based module schema mapping lookup."""
+
+    def test_lookup_by_version_returns_correct_url(self):
+        """Test that looking up by version returns the correct URL."""
+        url = get_module_schema_ref_by_version("AE", "1.2.0")
+        self.assertEqual(
+            url,
+            "http://www.eba.europa.eu/eu/fr/xbrl/crr/fws/ae/its-005-2020/2022-03-01/mod/ae.xsd",
+        )
+
+    def test_lookup_by_version_case_insensitive(self):
+        """Test that module code lookup is case insensitive."""
+        url_upper = get_module_schema_ref_by_version("AE", "1.2.0")
+        url_lower = get_module_schema_ref_by_version("ae", "1.2.0")
+        self.assertEqual(url_upper, url_lower)
+
+    def test_lookup_by_version_nonexistent_module_returns_none(self):
+        """Test that a non-existent module returns None."""
+        url = get_module_schema_ref_by_version("NONEXISTENT", "1.0.0")
+        self.assertIsNone(url)
+
+    def test_lookup_by_version_nonexistent_version_returns_none(self):
+        """Test that a non-existent version returns None."""
+        url = get_module_schema_ref_by_version("AE", "99.99.99")
+        self.assertIsNone(url)
+
+    def test_lookup_by_version_corep(self):
+        """Test lookup for COREP module by version."""
+        url = get_module_schema_ref_by_version("COREP_Con", "2.0.1")
+        self.assertEqual(
+            url,
+            "http://www.eba.europa.eu/eu/fr/xbrl/crr/fws/corep/its-2013-02/2013-12-01/mod/corep_con.xsd",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The static CSV mapping was only consulted for date-based lookups, causing release_id/release_code queries to generate wrong URLs (e.g. .../ae/3.4/mod/ae instead of .../ae/its-005-2020/2022-03-01/mod/ae.xsd). Now get_module_url always checks the static mapping by module code + version number before falling back to dynamic URL construction.

Closes #85